### PR TITLE
Allow piping a binary file to stdin

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 dependencies {
   implementation(project(":protogram"))
   implementation("com.github.ajalt", "clikt", "2.3.0")
+
+  testImplementation("junit", "junit", "4.13-rc-1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/cli/src/main/kotlin/com/mattprecious/protogram/main.kt
+++ b/cli/src/main/kotlin/com/mattprecious/protogram/main.kt
@@ -3,23 +3,36 @@
 package com.mattprecious.protogram
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.PrintHelpMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.arguments.optional
 import okio.ByteString.Companion.decodeHex
+import okio.buffer
+import okio.source
+import java.io.InputStream
 import java.io.PrintStream
 
 fun main(vararg args: String) {
-  ProtogramCli(System.out).main(args.toList())
+  ProtogramCli(System.`in`, System.out, System.err).main(args.toList())
 }
 
-private class ProtogramCli(
-  private val out: PrintStream
+internal class ProtogramCli(
+  private val stdin: InputStream,
+  private val stdout: PrintStream,
+  private val stderr: PrintStream
 ) : CliktCommand(name = "protogram") {
 
   private val bytes by argument("hex", "Encoded proto bytes as hex")
       .convert { it.decodeHex() }
+      .optional()
 
   override fun run() {
-    out.println(printProto(bytes))
+    if (bytes == null && stdin.available() == 0) {
+      stderr.println("Error: Attempted to read bytes from stdin but was empty.\n")
+      throw PrintHelpMessage(this)
+    }
+    val decodeBytes = bytes ?: stdin.source().buffer().readByteString()
+    stdout.print(printProto(decodeBytes))
   }
 }

--- a/cli/src/test/kotlin/com/mattprecious/protogram/ProtogramCliTest.kt
+++ b/cli/src/test/kotlin/com/mattprecious/protogram/ProtogramCliTest.kt
@@ -1,0 +1,56 @@
+package com.mattprecious.protogram
+
+import com.github.ajalt.clikt.core.PrintHelpMessage
+import okio.Buffer
+import okio.ByteString.Companion.decodeHex
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.PrintStream
+
+class ProtogramCliTest {
+  private val stdin = Buffer()
+  private val stdout = Buffer()
+  private val stderr = Buffer()
+
+  private val command = ProtogramCli(
+      stdin.inputStream(),
+      PrintStream(stdout.outputStream()),
+      PrintStream(stderr.outputStream())
+  )
+
+  @Test fun hex() {
+    command.parse(listOf("0804120610e80718c806"))
+
+    val expected = """
+      |┌─ 1: 4
+      |╰- 2 ┐
+      |     ├─ 2: 1000
+      |     ╰- 3: 840
+      |""".trimMargin()
+    assertEquals(expected, stdout.readUtf8())
+  }
+
+  @Test fun stdinBytes() {
+    stdin.write("0804120610e80718c806".decodeHex())
+    command.parse(listOf())
+
+    val expected = """
+      |┌─ 1: 4
+      |╰- 2 ┐
+      |     ├─ 2: 1000
+      |     ╰- 3: 840
+      |""".trimMargin()
+    assertEquals(expected, stdout.readUtf8())
+  }
+
+  @Test fun stdinEmpty() {
+    try {
+      command.parse(listOf())
+      fail()
+    } catch (_: PrintHelpMessage) {
+    }
+
+    assertEquals("Error: Attempted to read bytes from stdin but was empty.", stderr.readUtf8Line())
+  }
+}


### PR DESCRIPTION
```
$ cli/build/bin/protogram 0804120610e80718c806
┌─ 1: 4
╰- 2 ┐
     ├─ 2: 1000
     ╰- 3: 840

$ echo 0804120610e80718c806 | xxd -p -r > test.pb
$ cat test.pb | cli/build/bin/protogram
┌─ 1: 4
╰- 2 ┐
     ├─ 2: 1000
     ╰- 3: 840

$ cli/build/bin/protogram
Error: Attempted to read bytes from stdin but was empty.

Usage: protogram [OPTIONS] [hex]

Options:
  -h, --help  Show this message and exit

Arguments:
  hex  Encoded proto bytes as hex
```

Closes #13 