### PR TITLE
Allow pasting proto hex payloads with whitespace separators

### DIFF
--- a/webapp/src/main/kotlin/com/mattprecious/protogram/web/main.kt
+++ b/webapp/src/main/kotlin/com/mattprecious/protogram/web/main.kt
@@ -39,6 +39,7 @@ suspend fun main() = coroutineScope<Unit> {
   fun renderHex(value: String) {
     val tree = try {
       val trimmedValue = value.trim()
+          .replace(" ", "")
           .replace("\n", "")
       printProto(trimmedValue.decodeHex())
     } catch (e: Exception) {


### PR DESCRIPTION
Certain clients will render hex payloads with whitespace separators, and right now I've just been removing those whitespaces before pasting them into protogram.